### PR TITLE
fix: Adding strict to not accept string for int values in qubit count

### DIFF
--- a/src/braket/device_schema/gate_model_parameters_v1.py
+++ b/src/braket/device_schema/gate_model_parameters_v1.py
@@ -39,4 +39,4 @@ class GateModelParameters(BraketSchemaBase):
         name="braket.device_schema.gate_model_parameters", version="1"
     )
     braketSchemaHeader: BraketSchemaHeader = Field(default=_PROGRAM_HEADER, const=_PROGRAM_HEADER)
-    qubitCount: conint(ge=0)
+    qubitCount: conint(strict=True, ge=0)

--- a/test/unit_tests/braket/device_schema/test_gate_model_parameters_v1.py
+++ b/test/unit_tests/braket/device_schema/test_gate_model_parameters_v1.py
@@ -35,3 +35,16 @@ def test_valid():
 def test__missing_header():
     input = "{} "
     assert GateModelParameters.parse_raw_schema(input)
+
+
+def test_string_for_int_value():
+    input = {
+        "braketSchemaHeader": {
+            "name": "braket.device_schema.gate_model_parameters",
+            "version": "1",
+        },
+        "qubitCount": "1",
+    }
+    with pytest.raises(ValidationError) as e:
+        GateModelParameters.parse_raw_schema(json.dumps(input))
+    assert "value is not a valid integer" in str(e.value)

--- a/test/unit_tests/braket/ir/jaqcd/test_program_v1.py
+++ b/test/unit_tests/braket/ir/jaqcd/test_program_v1.py
@@ -62,9 +62,7 @@ def test_partial_non_rotation_basis_instruction():
 
 
 def test_no_rotation_basis_instruction():
-    Program(
-        instructions=[CNot(control=0, target=1)],
-    )
+    Program(instructions=[CNot(control=0, target=1)],)
 
 
 def test_rotation_basis_instruction():

--- a/test/unit_tests/braket/schema_common/test_schema_base.py
+++ b/test/unit_tests/braket/schema_common/test_schema_base.py
@@ -35,11 +35,7 @@ def test_header_name_incorrect():
 
 
 def test_import_schema_module():
-    schema = TaskMetadata(
-        id="test_id",
-        deviceId="device_id",
-        shots=1000,
-    )
+    schema = TaskMetadata(id="test_id", deviceId="device_id", shots=1000,)
     module = BraketSchemaBase.import_schema_module(schema)
     assert schema == module.TaskMetadata.parse_raw(schema.json())
 
@@ -55,10 +51,6 @@ def test_import_schema_module_error():
 
 
 def test_parse_raw_schema():
-    schema = TaskMetadata(
-        id="test_id",
-        deviceId="device_id",
-        shots=1000,
-    )
+    schema = TaskMetadata(id="test_id", deviceId="device_id", shots=1000,)
     assert schema == BraketSchemaBase.parse_raw_schema(schema.json())
     assert isinstance(schema, TaskMetadata)

--- a/test/unit_tests/braket/task_result/conftest.py
+++ b/test/unit_tests/braket/task_result/conftest.py
@@ -79,10 +79,7 @@ def dwave_timing():
 
 @pytest.fixture
 def dwave_metadata(active_variables, dwave_timing, braket_schema_header):
-    return DwaveMetadata(
-        activeVariables=active_variables,
-        timing=dwave_timing,
-    )
+    return DwaveMetadata(activeVariables=active_variables, timing=dwave_timing,)
 
 
 @pytest.fixture

--- a/test/unit_tests/braket/task_result/test_dwave_metadata_v1.py
+++ b/test/unit_tests/braket/task_result/test_dwave_metadata_v1.py
@@ -23,10 +23,7 @@ def test_missing_properties():
 
 
 def test_dwave_metadata_correct(active_variables, dwave_timing):
-    metadata = DwaveMetadata(
-        activeVariables=active_variables,
-        timing=dwave_timing,
-    )
+    metadata = DwaveMetadata(activeVariables=active_variables, timing=dwave_timing,)
     assert metadata.activeVariables == active_variables
     assert metadata.timing == dwave_timing
     assert DwaveMetadata.parse_raw(metadata.json()) == metadata
@@ -37,8 +34,7 @@ def test_dwave_metadata_correct(active_variables, dwave_timing):
 @pytest.mark.xfail(raises=ValidationError)
 def test_active_variables_incorrect(active_variables, dwave_timing):
     DwaveMetadata(
-        activeVariables=active_variables,
-        timing=dwave_timing,
+        activeVariables=active_variables, timing=dwave_timing,
     )
 
 

--- a/test/unit_tests/braket/task_result/test_gate_model_task_result_v1.py
+++ b/test/unit_tests/braket/task_result/test_gate_model_task_result_v1.py
@@ -64,10 +64,7 @@ def test_incorrect_header(
 
 
 def test_correct_result_measurements(
-    task_metadata,
-    additional_metadata_gate_model,
-    measured_qubits,
-    measurements,
+    task_metadata, additional_metadata_gate_model, measured_qubits, measurements,
 ):
     result = GateModelTaskResult(
         measurements=measurements,
@@ -84,10 +81,7 @@ def test_correct_result_measurements(
 
 
 def test_correct_result_measurement_probabilities(
-    task_metadata,
-    additional_metadata_gate_model,
-    measured_qubits,
-    measurement_probabilities,
+    task_metadata, additional_metadata_gate_model, measured_qubits, measurement_probabilities,
 ):
     result = GateModelTaskResult(
         measurementProbabilities=measurement_probabilities,
@@ -100,10 +94,7 @@ def test_correct_result_measurement_probabilities(
 
 
 def test_correct_result_types(
-    task_metadata,
-    additional_metadata_gate_model,
-    measured_qubits,
-    result_types,
+    task_metadata, additional_metadata_gate_model, measured_qubits, result_types,
 ):
     result = GateModelTaskResult(
         resultTypes=result_types,
@@ -129,10 +120,7 @@ def test_incorrect_measured_qubits(measured_qubits, task_metadata, additional_me
 @pytest.mark.parametrize("measurements", [([]), ([[]]), ([[-1]]), ([[2]])])
 @pytest.mark.xfail(raises=ValidationError)
 def test_incorrect_measurements(
-    measurements,
-    measured_qubits,
-    task_metadata,
-    additional_metadata_gate_model,
+    measurements, measured_qubits, task_metadata, additional_metadata_gate_model,
 ):
     GateModelTaskResult(
         measurements=measurements,
@@ -145,10 +133,7 @@ def test_incorrect_measurements(
 @pytest.mark.parametrize("measurement_probabilities", [({"hello": 0.5}), ({"01": 2})])
 @pytest.mark.xfail(raises=ValidationError)
 def test_incorrect_measurement_probabilities(
-    measurement_probabilities,
-    measured_qubits,
-    task_metadata,
-    additional_metadata_gate_model,
+    measurement_probabilities, measured_qubits, task_metadata, additional_metadata_gate_model,
 ):
     GateModelTaskResult(
         measurementProbabilities=measurement_probabilities,
@@ -161,10 +146,7 @@ def test_incorrect_measurement_probabilities(
 @pytest.mark.parametrize("result_types", [([1, 2, 3]), (3)])
 @pytest.mark.xfail(raises=ValidationError)
 def test_incorrect_result_types(
-    task_metadata,
-    additional_metadata_gate_model,
-    measured_qubits,
-    result_types,
+    task_metadata, additional_metadata_gate_model, measured_qubits, result_types,
 ):
     GateModelTaskResult(
         resultTypes=result_types,

--- a/test/unit_tests/braket/task_result/test_rigetti_metadata_v1.py
+++ b/test/unit_tests/braket/task_result/test_rigetti_metadata_v1.py
@@ -36,8 +36,7 @@ def test_rigetti_metadata_correct(compiled_program, native_quil_metadata):
 @pytest.mark.xfail(raises=ValidationError)
 def test_compiled_program_incorrect(compiled_program, native_quil_metadata):
     RigettiMetadata(
-        compiledProgram=compiled_program,
-        nativeQuilMetadata=native_quil_metadata,
+        compiledProgram=compiled_program, nativeQuilMetadata=native_quil_metadata,
     )
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
As of today when we provide qubitCount = "1" it will be auto converted to 1 (int value). Making it strict so that we fail if customers provide string value for qubitCount. This is required in service to make sure we persist the right type of data. 
*Testing done:*
Added test case to prove it will fail if provided string value. 
## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-schemas-python/blob/main/CONTRIBUTING.md) doc
- [ x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-schemas-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-schemas-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-schemas-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
