### PR TITLE
Adding strict to not accept string for int values in qubit count

### DIFF
--- a/src/braket/device_schema/gate_model_parameters_v1.py
+++ b/src/braket/device_schema/gate_model_parameters_v1.py
@@ -39,4 +39,4 @@ class GateModelParameters(BraketSchemaBase):
         name="braket.device_schema.gate_model_parameters", version="1"
     )
     braketSchemaHeader: BraketSchemaHeader = Field(default=_PROGRAM_HEADER, const=_PROGRAM_HEADER)
-    qubitCount: conint(ge=0)
+    qubitCount: conint(strict=True, ge=0)

--- a/test/unit_tests/braket/device_schema/test_gate_model_parameters_v1.py
+++ b/test/unit_tests/braket/device_schema/test_gate_model_parameters_v1.py
@@ -35,3 +35,16 @@ def test_valid():
 def test__missing_header():
     input = "{} "
     assert GateModelParameters.parse_raw_schema(input)
+
+
+def test_string_for_int_value():
+    input = {
+        "braketSchemaHeader": {
+            "name": "braket.device_schema.gate_model_parameters",
+            "version": "1",
+        },
+        "qubitCount": "1",
+    }
+    with pytest.raises(ValidationError) as e:
+        GateModelParameters.parse_raw_schema(json.dumps(input))
+    assert "value is not a valid integer" in str(e.value)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
As of today when we provide qubitCount = "1" it will be auto converted to 1 (int value). Making it strict so that we fail if customers provide string value for qubitCount. This is required in service to make sure we persist the right type of data.

*Testing done:*
Added test case to prove it will fail if provided string value.


## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-schemas-python/blob/main/CONTRIBUTING.md) doc
- [ x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-schemas-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-schemas-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-schemas-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
