### PR TITLE
documentation: fix time unit for D-Wave metadata from milliseconds to…

### DIFF
--- a/src/braket/task_result/dwave_metadata_v1.py
+++ b/src/braket/task_result/dwave_metadata_v1.py
@@ -22,7 +22,7 @@ class DwaveTiming(BaseModel):
     """
     The D-Wave timing metadata result schema.
 
-    The times represented are in milliseconds.
+    The times represented are in microseconds.
 
     Examples:
         >>> DwaveTiming(qpuSamplingTime=1575, qpuAnnealTimePerSample=20)


### PR DESCRIPTION
… microseconds

*Issue #, if available:* NA

*Description of changes:* Fixed documentation of D-Wave  timing metadata to reflect the correct time unit (microseconds)

*Testing done:* Ran the unit tests. No regressions.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-schemas-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-schemas-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-schemas-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-schemas-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
