### PR TITLE
feature: support for StartPreserveBlock and EndPreserveBlock instruct…

### DIFF
--- a/src/braket/ir/jaqcd/__init__.py
+++ b/src/braket/ir/jaqcd/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2019-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -28,6 +28,7 @@ from braket.ir.jaqcd.instructions import (  # noqa: F401
     CPhaseShift10,
     CSwap,
     Depolarizing,
+    EndVerbatimBlock,
     GeneralizedAmplitudeDamping,
     H,
     I,
@@ -43,6 +44,7 @@ from braket.ir.jaqcd.instructions import (  # noqa: F401
     Rz,
     S,
     Si,
+    StartVerbatimBlock,
     Swap,
     T,
     Ti,

--- a/src/braket/ir/jaqcd/instructions.py
+++ b/src/braket/ir/jaqcd/instructions.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2019-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -15,6 +15,7 @@ from enum import Enum
 
 from braket.ir.jaqcd.shared_models import (
     Angle,
+    CompilerDirective,
     DampingProbability,
     DampingSingleProbability,
     DoubleControl,
@@ -899,3 +900,47 @@ class Kraus(TwoDimensionalMatrixList, MultiTarget):
         kraus = "kraus"
 
     type = Type.kraus
+
+
+class StartVerbatimBlock(CompilerDirective):
+    """
+    StartVerbatimBLock is a compiler instruction to start the code block which
+    will preserve the instruction within StartPreserveBlock and EndVerbatimBlock
+    from being modified in any way by the compiler.
+
+    Attributes:
+        type (str): The instruction type. default = "start_verbatim_block". (type) is optional.
+            This should be unique among all instruction types.
+
+    Examples:
+        >>> StartVerbatimBlock()
+    """
+
+    class Type(str, Enum):
+        start_verbatim_block = "start_verbatim_block"
+
+    type = Type.start_verbatim_block
+
+    directive: str = "StartVerbatimBlock"
+
+
+class EndVerbatimBlock(CompilerDirective):
+    """
+    EndVerbatimBlock is a compiler instruction to mark the end of the code block
+    which will preserve the instruction within StartPreserveBlock and EndVerbatimBlock
+    from being  modified in any way by the compiler.
+
+    Attributes:
+        type (str): The instruction type. default = "end_verbatim_block". (type) is optional.
+            This should be unique among all instruction types.
+
+    Examples:
+        >>> EndVerbatimBlock()
+    """
+
+    class Type(str, Enum):
+        end_verbatim_block = "end_verbatim_block"
+
+    type = Type.end_verbatim_block
+
+    directive: str = "EndVerbatimBlock"

--- a/src/braket/ir/jaqcd/program_v1.py
+++ b/src/braket/ir/jaqcd/program_v1.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2019-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -32,6 +32,7 @@ from braket.ir.jaqcd.instructions import (
     CPhaseShift10,
     CSwap,
     Depolarizing,
+    EndVerbatimBlock,
     GeneralizedAmplitudeDamping,
     H,
     I,
@@ -47,6 +48,7 @@ from braket.ir.jaqcd.instructions import (
     Rz,
     S,
     Si,
+    StartVerbatimBlock,
     Swap,
     T,
     Ti,
@@ -120,6 +122,11 @@ _valid_noise_channels = {
     TwoQubitDephasing.Type.two_qubit_dephasing: TwoQubitDephasing,
     TwoQubitDepolarizing.Type.two_qubit_depolarizing: TwoQubitDepolarizing,
     Kraus.Type.kraus: Kraus,
+}
+
+_valid_compiler_directives = {
+    StartVerbatimBlock.Type.start_verbatim_block: StartVerbatimBlock,
+    EndVerbatimBlock.Type.end_verbatim_block: EndVerbatimBlock,
 }
 
 Results = Union[Amplitude, Expectation, Probability, Sample, StateVector, DensityMatrix, Variance]
@@ -207,8 +214,12 @@ class Program(BraketSchemaBase):
         2. Validate that the input instructions are supported
         """
         if isinstance(value, BaseModel):
-            if (value.type not in _valid_gates) and (value.type not in _valid_noise_channels):
-                raise ValueError(f"Invalid gate specified: {value} for field: {field}")
+            if (
+                (value.type not in _valid_gates)
+                and (value.type not in _valid_noise_channels)
+                and (value.type not in _valid_compiler_directives)
+            ):
+                raise ValueError(f"Invalid value.type specified: {value} for field: {field}")
             return value
 
         if value is not None and "type" in value:
@@ -216,7 +227,9 @@ class Program(BraketSchemaBase):
                 return _valid_gates[value["type"]](**value)
             elif value["type"] in _valid_noise_channels:
                 return _valid_noise_channels[value["type"]](**value)
+            elif value["type"] in _valid_compiler_directives:
+                return _valid_compiler_directives[value["type"]](**value)
             else:
-                raise ValueError(f"Invalid gate specified: {value} for field: {field}")
+                raise ValueError(f"Invalid instruction specified: {value} for field: {field}")
         else:
-            raise ValueError(f"Invalid gate specified: {value} for field: {field}")
+            raise ValueError(f"Invalid type or value specified: {value} for field: {field}")

--- a/src/braket/ir/jaqcd/shared_models.py
+++ b/src/braket/ir/jaqcd/shared_models.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2019-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -335,3 +335,19 @@ class MultiState(BaseModel):
     """
 
     states: conlist(constr(regex="^[01]+$", min_length=1), min_items=1)
+
+
+class CompilerDirective(BaseModel):
+    """
+    A Compiler Directive to preserve a block of code between StartVerbatimBlock
+    and EndVerbatimBlock directives.
+
+    Attributes:
+        directive (List [StartVerbatimBlock | EndVerbatimBlock])
+
+    Examples:
+        >>> CompilerDirective (directive="StartVerbatimBlock")
+        >>> CompilerDirective (directive="EndVerbatimBlock")
+    """
+
+    directive: constr(regex="^(Start|End)VerbatimBlock$")

--- a/test/unit_tests/braket/ir/jaqcd/test_program_v1.py
+++ b/test/unit_tests/braket/ir/jaqcd/test_program_v1.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2019-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -14,7 +14,7 @@
 import pytest
 from pydantic import ValidationError
 
-from braket.ir.jaqcd import BitFlip, CNot, Expectation, H
+from braket.ir.jaqcd import BitFlip, CNot, EndVerbatimBlock, Expectation, H, StartVerbatimBlock
 from braket.ir.jaqcd.program_v1 import Program
 
 
@@ -79,3 +79,15 @@ def test_no_rotation_basis_instruction():
 
 def test_rotation_basis_instruction():
     Program(instructions=[CNot(control=0, target=1)], basis_rotation_instructions=[H(target=1)])
+
+
+def test_start_verbatim_block_instruction():
+    Program(instructions=[StartVerbatimBlock()])
+
+
+def test_end_verbatim_block_instruction():
+    Program(instructions=[EndVerbatimBlock()])
+
+
+def test_type_validation_for_compiler_directive():
+    Program(instructions=[{"type": "end_verbatim_block"}])


### PR DESCRIPTION
…ions.

*Issue #, if available:*

*Description of changes:*
Support added for StartPreserveBlock and EndPreserveBlock instructions. The code between the start and end instructions will not be optimized by removing, reordering, or decomposing. Thus, creating a preserved block of code.

I've also updated the error messages in program_v1.py. There are three code paths that all had the same error message, so I've separated them into unique messages to help with future debugging.

*Testing done:*
```
==================================================================================== test session starts =====================================================================================
platform darwin -- Python 3.7.6, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- /usr/local/opt/python/bin/python3.7
cachedir: .pytest_cache
rootdir: .../amazon-braket-schemas-python, configfile: setup.cfg
collected 14 items                                                                                                                                                                           

test/unit_tests/braket/ir/jaqcd/test_program_v1.py::test_missing_instructions_property XFAIL                                                                                           [  7%]
test/unit_tests/braket/ir/jaqcd/test_program_v1.py::test_non_instruction XFAIL                                                                                                         [ 14%]
test/unit_tests/braket/ir/jaqcd/test_program_v1.py::test_wrong_instruction XFAIL                                                                                                       [ 21%]
test/unit_tests/braket/ir/jaqcd/test_program_v1.py::test_wrong_compiler_directive XFAIL                                                                                                [ 28%]
test/unit_tests/braket/ir/jaqcd/test_program_v1.py::test_partial_non_instruction XFAIL                                                                                                 [ 35%]
test/unit_tests/braket/ir/jaqcd/test_program_v1.py::test_partial_non_result XFAIL                                                                                                      [ 42%]
test/unit_tests/braket/ir/jaqcd/test_program_v1.py::test_instruction_no_results PASSED                                                                                                 [ 50%]
test/unit_tests/braket/ir/jaqcd/test_program_v1.py::test_instruction_no_noise_results PASSED                                                                                           [ 57%]
test/unit_tests/braket/ir/jaqcd/test_program_v1.py::test_instruction_with_results PASSED                                                                                               [ 64%]
test/unit_tests/braket/ir/jaqcd/test_program_v1.py::test_partial_non_rotation_basis_instruction XFAIL                                                                                  [ 71%]
test/unit_tests/braket/ir/jaqcd/test_program_v1.py::test_no_rotation_basis_instruction PASSED                                                                                          [ 78%]
test/unit_tests/braket/ir/jaqcd/test_program_v1.py::test_rotation_basis_instruction PASSED                                                                                             [ 85%]
test/unit_tests/braket/ir/jaqcd/test_program_v1.py::test_start_preserve_block_instruction PASSED                                                                                       [ 92%]
test/unit_tests/braket/ir/jaqcd/test_program_v1.py::test_end_preserve_block_instruction PASSED                                                                                         [100%]

================================================================================ 7 passed, 7 xfailed in 0.19s ================================================================================
~
```
## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-schemas-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-schemas-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-schemas-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-schemas-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
