### PR TITLE
fix: change annealingDurationRange to a list of floats.

### DIFF
--- a/src/braket/device_schema/dwave/dwave_2000Q_device_level_parameters_v1.py
+++ b/src/braket/device_schema/dwave/dwave_2000Q_device_level_parameters_v1.py
@@ -82,7 +82,7 @@ class Dwave2000QDeviceLevelParameters(BraketSchemaBase):
     braketSchemaHeader: BraketSchemaHeader = Field(default=_PROGRAM_HEADER, const=_PROGRAM_HEADER)
     annealingOffsets: Optional[List[float]]
     annealingSchedule: Optional[List[List[float]]]
-    annealingDuration: Optional[int] = Field(gt=0)
+    annealingDuration: Optional[float] = Field(gt=0)
     autoScale: Optional[bool]
     beta: Optional[float]
     chains: Optional[List[List[int]]]

--- a/src/braket/device_schema/dwave/dwave_advantage_device_level_parameters_v1.py
+++ b/src/braket/device_schema/dwave/dwave_advantage_device_level_parameters_v1.py
@@ -71,7 +71,7 @@ class DwaveAdvantageDeviceLevelParameters(BraketSchemaBase):
     braketSchemaHeader: BraketSchemaHeader = Field(default=_PROGRAM_HEADER, const=_PROGRAM_HEADER)
     annealingOffsets: Optional[List[float]]
     annealingSchedule: Optional[List[List[float]]]
-    annealingDuration: Optional[int] = Field(gt=0)
+    annealingDuration: Optional[float] = Field(gt=0)
     autoScale: Optional[bool]
     compensateFluxDrift: Optional[bool]
     fluxBiases: Optional[List[float]]

--- a/src/braket/device_schema/dwave/dwave_device_capabilities_v1.py
+++ b/src/braket/device_schema/dwave/dwave_device_capabilities_v1.py
@@ -41,7 +41,7 @@ class DwaveDeviceCapabilities(DeviceCapabilities, BraketSchemaBase):
         ...        "annealingOffsetStep": 1.45,
         ...        "annealingOffsetStepPhi0": 1.45,
         ...        "annealingOffsetRanges": [[1.45, 1.45], [1.45, 1.45]],
-        ...        "annealingDurationRange": [1, 2, 3],
+        ...        "annealingDurationRange": [1.45, 2.45, 3],
         ...        "couplers": [[1, 2, 3], [1, 2, 3]],
         ...        "defaultAnnealingDuration": 1,
         ...        "defaultProgrammingThermalizationDuration": 1,

--- a/src/braket/device_schema/dwave/dwave_provider_properties_v1.py
+++ b/src/braket/device_schema/dwave/dwave_provider_properties_v1.py
@@ -39,7 +39,7 @@ class DwaveProviderProperties(BraketSchemaBase):
         ...    "annealingOffsetStep": 1.45,
         ...    "annealingOffsetStepPhi0": 1.45,
         ...    "annealingOffsetRanges": [[1.45, 1.45], [1.45, 1.45]],
-        ...    "annealingDurationRange": [1, 2, 3],
+        ...    "annealingDurationRange": [1.45, 2.45, 3],
         ...    "couplers": [[1, 2, 3], [1, 2, 3]],
         ...    "defaultAnnealingDuration": 1,
         ...    "defaultProgrammingThermalizationDuration": 1,
@@ -69,7 +69,7 @@ class DwaveProviderProperties(BraketSchemaBase):
     annealingOffsetStep: float
     annealingOffsetStepPhi0: float
     annealingOffsetRanges: List[List[float]]
-    annealingDurationRange: List[int]
+    annealingDurationRange: List[float]
     couplers: List[List[int]]
     defaultAnnealingDuration: int
     defaultProgrammingThermalizationDuration: int

--- a/test/unit_tests/braket/device_schema/dwave/test_dwave_2000Q_device_level_parameters_v1.py
+++ b/test/unit_tests/braket/device_schema/dwave/test_dwave_2000Q_device_level_parameters_v1.py
@@ -25,7 +25,7 @@ from braket.device_schema.dwave.dwave_provider_level_parameters_v1 import (
 
 @pytest.mark.parametrize(
     "annealing_duration",
-    (1, 500, pytest.param(0, marks=pytest.mark.xfail(reason="positive int constraint"))),
+    (0.5, 1.5, 500, pytest.param(0, marks=pytest.mark.xfail(reason="positive int constraint"))),
 )
 @pytest.mark.parametrize(
     "max_results",

--- a/test/unit_tests/braket/device_schema/dwave/test_dwave_advantage_device_level_parameters_v1.py
+++ b/test/unit_tests/braket/device_schema/dwave/test_dwave_advantage_device_level_parameters_v1.py
@@ -28,7 +28,7 @@ from braket.device_schema.dwave.dwave_provider_level_parameters_v1 import (
 
 @pytest.mark.parametrize(
     "annealing_duration",
-    (1, 500, pytest.param(0, marks=pytest.mark.xfail(reason="positive int constraint"))),
+    (0.5, 1.5, 500, pytest.param(0, marks=pytest.mark.xfail(reason="positive int constraint"))),
 )
 @pytest.mark.parametrize(
     "max_results",

--- a/test/unit_tests/braket/device_schema/dwave/test_dwave_device_capabilities_v1.py
+++ b/test/unit_tests/braket/device_schema/dwave/test_dwave_device_capabilities_v1.py
@@ -34,7 +34,7 @@ def valid_input():
             "annealingOffsetStep": 1.45,
             "annealingOffsetStepPhi0": 1.45,
             "annealingOffsetRanges": [[1.45, 1.45], [1.45, 1.45]],
-            "annealingDurationRange": [1, 2, 3],
+            "annealingDurationRange": [1.45, 2.45, 3],
             "couplers": [[1, 2, 3], [1, 2, 3]],
             "defaultAnnealingDuration": 1,
             "defaultProgrammingThermalizationDuration": 1,

--- a/test/unit_tests/braket/device_schema/dwave/test_dwave_provider_properties_v1.py
+++ b/test/unit_tests/braket/device_schema/dwave/test_dwave_provider_properties_v1.py
@@ -29,7 +29,7 @@ def valid_input():
         "annealingOffsetStep": 1.45,
         "annealingOffsetStepPhi0": 1.45,
         "annealingOffsetRanges": [[1.45, 1.45], [1.45, 1.45]],
-        "annealingDurationRange": [1, 2, 3],
+        "annealingDurationRange": [1.45, 2.45, 3],
         "couplers": [[1, 2, 3], [1, 2, 3]],
         "defaultAnnealingDuration": 1,
         "defaultProgrammingThermalizationDuration": 1,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
It's possible for device configurations to give us a time as a fraction of a second, therefore annealingDurationRange should be a list of floats, rather than ints.

*Testing done:*
tox

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-schemas-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-schemas-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-schemas-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-schemas-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
