### PR TITLE
fix: Make provider properties specs to keep consistent with similar properties for other QHPs. Make OneQubit gate number an integer instead of a float

### DIFF
--- a/src/braket/device_schema/oqc/oqc_provider_properties_v1.py
+++ b/src/braket/device_schema/oqc/oqc_provider_properties_v1.py
@@ -20,10 +20,8 @@ from braket.schema_common import BraketSchemaBase, BraketSchemaHeader
 # TODO: Replace the calibration data with actual values we receive from the device.
 
 
-OneQubitType = TypeVar("OneQubitType", bound=Union[int, Dict[str, Union[float, int]]])
+OneQubitType = TypeVar("OneQubitType", bound=Dict[str, Union[float, int]])
 TwoQubitType = TypeVar("TwoQubitType", bound=Dict[str, Union[float, Dict[str, int]]])
-
-QubitType = TypeVar("QubitType", bound=Dict[str, Union[OneQubitType, TwoQubitType]])
 
 
 class OqcProviderProperties(BraketSchemaBase):
@@ -31,7 +29,7 @@ class OqcProviderProperties(BraketSchemaBase):
     This defines the properties common to all the OQC devices.
 
     Attributes:
-        specs (Dict[str, Dict[str, Union[OneQubitType, TwoQubitType]]): Basic specifications for
+        specs (Dict[str, Dict[str, Union[OneQubitType, TwoQubitType]]]): Basic specifications for
             the device, such as gate fidelities and coherence times.
 
     Examples:
@@ -42,7 +40,7 @@ class OqcProviderProperties(BraketSchemaBase):
         ...     "version": "1",
         ... },
         ... "specs": {
-        ...     "one_qubit": {
+        ...     "1Q": {
         ...         "0": {
         ...             "T1": 28.9,
         ...             "T2": 44.5,
@@ -51,13 +49,13 @@ class OqcProviderProperties(BraketSchemaBase):
         ...             "qubit": 0
         ...         },
         ...     },
-        ...     "two_qubit": {
+        ...     "2Q": {
         ...         "0-1": {
         ...             "coupling": {
         ...                 "control_qubit": 0,
         ...                 "target_qubit": 1
         ...             },
-        ...             "fCX": 87.7
+        ...             "fCNOT": 87.7
         ...         },
         ...     }
         ... },
@@ -69,4 +67,4 @@ class OqcProviderProperties(BraketSchemaBase):
         name="braket.device_schema.oqc.oqc_provider_properties", version="1"
     )
     braketSchemaHeader: BraketSchemaHeader = Field(default=_PROGRAM_HEADER, const=_PROGRAM_HEADER)
-    specs: Dict[str, Dict[str, QubitType]]
+    specs: Dict[str, Dict[str, Union[OneQubitType, TwoQubitType]]]

--- a/src/braket/device_schema/oqc/oqc_provider_properties_v1.py
+++ b/src/braket/device_schema/oqc/oqc_provider_properties_v1.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from typing import Dict, List, TypeVar, Union
+from typing import Dict, TypeVar, Union
 
 from pydantic import Field
 
@@ -20,8 +20,7 @@ from braket.schema_common import BraketSchemaBase, BraketSchemaHeader
 # TODO: Replace the calibration data with actual values we receive from the device.
 
 
-GateFidelityType = TypeVar("GateFidelityType", bound=Dict[str, Union[str, float]])
-OneQubitType = TypeVar("OneQubitType", bound=Union[float, List[GateFidelityType]])
+OneQubitType = TypeVar("OneQubitType", bound=Union[int, Dict[str, Union[float, int]]])
 TwoQubitType = TypeVar("TwoQubitType", bound=Dict[str, Union[float, Dict[str, int]]])
 
 QubitType = TypeVar("QubitType", bound=Dict[str, Union[OneQubitType, TwoQubitType]])
@@ -32,7 +31,7 @@ class OqcProviderProperties(BraketSchemaBase):
     This defines the properties common to all the OQC devices.
 
     Attributes:
-        properties (Dict[str, Dict[str, Union[int, List[int]]]]): Basic specifications for
+        specs (Dict[str, Dict[str, Union[OneQubitType, TwoQubitType]]): Basic specifications for
             the device, such as gate fidelities and coherence times.
 
     Examples:
@@ -42,28 +41,25 @@ class OqcProviderProperties(BraketSchemaBase):
         ...     "name": "braket.device_schema.oqc.oqc_provider_properties",
         ...     "version": "1",
         ... },
-        ... "properties": {
+        ... "specs": {
         ...     "one_qubit": {
         ...         "0": {
-        ...             "T1": 12.2,
-        ...             "T2": 13.5,
-        ...             "fRO": 0.99,
-        ...             "fRB": 0.98,
-        ...             "native-gate-fidelities": [
-        ...                 {"native-gate": "rz", "CLf": 0.99},
-        ...                 {"native-gate": "sx", "CLf": 0.99},
-        ...                 {"native-gate": "x", "CLf": 0.99},
-        ...             ],
-        ...             "EPE": 0.001,
+        ...             "T1": 28.9,
+        ...             "T2": 44.5,
+        ...             "fRB": 99.93,
+        ...             "fRO": 90.3,
+        ...             "qubit": 0
         ...         },
         ...     },
         ...     "two_qubit": {
         ...         "0-1": {
-        ...             "coupling": {"control_qubit": 0, "target_qubit": 1},
-        ...             "CLf": 0.99,
-        ...             "ECR_f": 0.99,
+        ...             "coupling": {
+        ...                 "control_qubit": 0,
+        ...                 "target_qubit": 1
+        ...             },
+        ...             "fCX": 87.7
         ...         },
-        ...     },
+        ...     }
         ... },
         ... }
         >>> OqcProviderProperties.parse_raw_schema(json.dumps(input_json))
@@ -73,4 +69,4 @@ class OqcProviderProperties(BraketSchemaBase):
         name="braket.device_schema.oqc.oqc_provider_properties", version="1"
     )
     braketSchemaHeader: BraketSchemaHeader = Field(default=_PROGRAM_HEADER, const=_PROGRAM_HEADER)
-    properties: Dict[str, Dict[str, QubitType]]
+    specs: Dict[str, Dict[str, QubitType]]

--- a/test/unit_tests/braket/device_schema/oqc/test_oqc_provider_properties_v1.py
+++ b/test/unit_tests/braket/device_schema/oqc/test_oqc_provider_properties_v1.py
@@ -27,7 +27,7 @@ def valid_input():
             "version": "1",
         },
         "specs": {
-            "one_qubit": {
+            "1Q": {
                 "0": {"T1": 12.2, "T2": 13.5, "fRO": 0.99, "fRB": 0.98, "qubit": 0},
                 "1": {"T1": 12.2, "T2": 13.5, "fRO": 0.99, "fRB": 0.98, "qubit": 1},
                 "2": {"T1": 12.2, "T2": 13.5, "fRO": 0.99, "fRB": 0.98, "qubit": 2},
@@ -37,38 +37,38 @@ def valid_input():
                 "6": {"T1": 12.2, "T2": 13.5, "fRO": 0.99, "fRB": 0.98, "qubit": 6},
                 "7": {"T1": 12.2, "T2": 13.5, "fRO": 0.99, "fRB": 0.98, "qubit": 7},
             },
-            "two_qubit": {
+            "2Q": {
                 "0-1": {
                     "coupling": {"control_qubit": 0, "target_qubit": 1},
-                    "fCX": 0.99,
+                    "fCNOT": 0.99,
                 },
                 "1-2": {
                     "coupling": {"control_qubit": 1, "target_qubit": 2},
-                    "fCX": 0.99,
+                    "fCNOT": 0.99,
                 },
                 "2-3": {
                     "coupling": {"control_qubit": 2, "target_qubit": 3},
-                    "fCX": 0.99,
+                    "fCNOT": 0.99,
                 },
                 "3-4": {
                     "coupling": {"control_qubit": 3, "target_qubit": 4},
-                    "fCX": 0.99,
+                    "fCNOT": 0.99,
                 },
                 "4-5": {
                     "coupling": {"control_qubit": 4, "target_qubit": 5},
-                    "fCX": 0.99,
+                    "fCNOT": 0.99,
                 },
                 "5-6": {
                     "coupling": {"control_qubit": 5, "target_qubit": 6},
-                    "fCX": 0.99,
+                    "fCNOT": 0.99,
                 },
                 "6-7": {
                     "coupling": {"control_qubit": 6, "target_qubit": 7},
-                    "fCX": 0.99,
+                    "fCNOT": 0.99,
                 },
                 "7-0": {
                     "coupling": {"control_qubit": 7, "target_qubit": 0},
-                    "fCX": 0.99,
+                    "fCNOT": 0.99,
                 },
             },
         },

--- a/test/unit_tests/braket/device_schema/oqc/test_oqc_provider_properties_v1.py
+++ b/test/unit_tests/braket/device_schema/oqc/test_oqc_provider_properties_v1.py
@@ -26,145 +26,49 @@ def valid_input():
             "name": "braket.device_schema.oqc.oqc_provider_properties",
             "version": "1",
         },
-        "properties": {
+        "specs": {
             "one_qubit": {
-                "0": {
-                    "T1": 12.2,
-                    "T2": 13.5,
-                    "fRO": 0.99,
-                    "fRB": 0.98,
-                    "native_gate_fidelities": [
-                        {"native_gate": "rz", "CLf": 0.99},
-                        {"native_gate": "sx", "CLf": 0.99},
-                        {"native_gate": "x", "CLf": 0.99},
-                    ],
-                    "EPE": 0.001,
-                },
-                "1": {
-                    "T1": 12.2,
-                    "T2": 13.5,
-                    "fRO": 0.99,
-                    "fRB": 0.98,
-                    "native_gate_fidelities": [
-                        {"native_gate": "rz", "CLf": 0.99},
-                        {"native_gate": "sx", "CLf": 0.99},
-                        {"native_gate": "x", "CLf": 0.99},
-                    ],
-                    "EPE": 0.001,
-                },
-                "2": {
-                    "T1": 12.2,
-                    "T2": 13.5,
-                    "fRO": 0.99,
-                    "fRB": 0.98,
-                    "native_gate_fidelities": [
-                        {"native_gate": "rz", "CLf": 0.99},
-                        {"native_gate": "sx", "CLf": 0.99},
-                        {"native_gate": "x", "CLf": 0.99},
-                    ],
-                    "EPE": 0.001,
-                },
-                "3": {
-                    "T1": 12.2,
-                    "T2": 13.5,
-                    "fRO": 0.99,
-                    "fRB": 0.98,
-                    "native_gate_fidelities": [
-                        {"native_gate": "rz", "CLf": 0.99},
-                        {"native_gate": "sx", "CLf": 0.99},
-                        {"native_gate": "x", "CLf": 0.99},
-                    ],
-                    "EPE": 0.001,
-                },
-                "4": {
-                    "T1": 12.2,
-                    "T2": 13.5,
-                    "fRO": 0.99,
-                    "fRB": 0.98,
-                    "native_gate_fidelities": [
-                        {"native_gate": "rz", "CLf": 0.99},
-                        {"native_gate": "sx", "CLf": 0.99},
-                        {"native_gate": "x", "CLf": 0.99},
-                    ],
-                    "EPE": 0.001,
-                },
-                "5": {
-                    "T1": 12.2,
-                    "T2": 13.5,
-                    "fRO": 0.99,
-                    "fRB": 0.98,
-                    "native_gate_fidelities": [
-                        {"native_gate": "rz", "CLf": 0.99},
-                        {"native_gate": "sx", "CLf": 0.99},
-                        {"native_gate": "x", "CLf": 0.99},
-                    ],
-                    "EPE": 0.001,
-                },
-                "6": {
-                    "T1": 12.2,
-                    "T2": 13.5,
-                    "fRO": 0.99,
-                    "fRB": 0.98,
-                    "native_gate_fidelities": [
-                        {"native_gate": "rz", "CLf": 0.99},
-                        {"native_gate": "sx", "CLf": 0.99},
-                        {"native_gate": "x", "CLf": 0.99},
-                    ],
-                    "EPE": 0.001,
-                },
-                "7": {
-                    "T1": 12.2,
-                    "T2": 13.5,
-                    "fRO": 0.99,
-                    "fRB": 0.98,
-                    "native_gate_fidelities": [
-                        {"native_gate": "rz", "CLf": 0.99},
-                        {"native_gate": "sx", "CLf": 0.99},
-                        {"native_gate": "x", "CLf": 0.99},
-                    ],
-                    "EPE": 0.001,
-                },
+                "0": {"T1": 12.2, "T2": 13.5, "fRO": 0.99, "fRB": 0.98, "qubit": 0},
+                "1": {"T1": 12.2, "T2": 13.5, "fRO": 0.99, "fRB": 0.98, "qubit": 1},
+                "2": {"T1": 12.2, "T2": 13.5, "fRO": 0.99, "fRB": 0.98, "qubit": 2},
+                "3": {"T1": 12.2, "T2": 13.5, "fRO": 0.99, "fRB": 0.98, "qubit": 3},
+                "4": {"T1": 12.2, "T2": 13.5, "fRO": 0.99, "fRB": 0.98, "qubit": 4},
+                "5": {"T1": 12.2, "T2": 13.5, "fRO": 0.99, "fRB": 0.98, "qubit": 5},
+                "6": {"T1": 12.2, "T2": 13.5, "fRO": 0.99, "fRB": 0.98, "qubit": 6},
+                "7": {"T1": 12.2, "T2": 13.5, "fRO": 0.99, "fRB": 0.98, "qubit": 7},
             },
             "two_qubit": {
                 "0-1": {
                     "coupling": {"control_qubit": 0, "target_qubit": 1},
-                    "CLf": 0.99,
-                    "ECR_f": 0.99,
+                    "fCX": 0.99,
                 },
                 "1-2": {
                     "coupling": {"control_qubit": 1, "target_qubit": 2},
-                    "CLf": 0.99,
-                    "ECR_f": 0.99,
+                    "fCX": 0.99,
                 },
                 "2-3": {
                     "coupling": {"control_qubit": 2, "target_qubit": 3},
-                    "CLf": 0.99,
-                    "ECR_f": 0.99,
+                    "fCX": 0.99,
                 },
                 "3-4": {
                     "coupling": {"control_qubit": 3, "target_qubit": 4},
-                    "CLf": 0.99,
-                    "ECR_f": 0.99,
+                    "fCX": 0.99,
                 },
                 "4-5": {
                     "coupling": {"control_qubit": 4, "target_qubit": 5},
-                    "CLf": 0.99,
-                    "ECR_f": 0.99,
+                    "fCX": 0.99,
                 },
                 "5-6": {
                     "coupling": {"control_qubit": 5, "target_qubit": 6},
-                    "CLf": 0.99,
-                    "ECR_f": 0.99,
+                    "fCX": 0.99,
                 },
                 "6-7": {
                     "coupling": {"control_qubit": 6, "target_qubit": 7},
-                    "CLf": 0.99,
-                    "ECR_f": 0.99,
+                    "fCX": 0.99,
                 },
                 "7-0": {
                     "coupling": {"control_qubit": 7, "target_qubit": 0},
-                    "CLf": 0.99,
-                    "ECR_f": 0.99,
+                    "fCX": 0.99,
                 },
             },
         },
@@ -177,7 +81,7 @@ def test_valid(valid_input):
     assert result.braketSchemaHeader.name == "braket.device_schema.oqc.oqc_provider_properties"
 
 
-@pytest.mark.parametrize("missing_field", ["braketSchemaHeader", "properties"])
+@pytest.mark.parametrize("missing_field", ["braketSchemaHeader", "specs"])
 def test_missing_field(valid_input, missing_field):
     with pytest.raises(ValidationError):
         valid_input.pop(missing_field)


### PR DESCRIPTION
Make provider properties specs to keep consistent with similar properties for other QHPs. Make OneQubit gate number an integer instead of a float

#### Description of changes

gate number should be an int instead of a float
make "properties" "specs" to make consistent with Rigetti

#### Testing done
```
tox
```
#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-schemas-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-schemas-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-schemas-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-schemas-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
