### PR TITLE
Update quera ahs paradigm schema with timeMin and timeMax

### DIFF
--- a/src/braket/device_schema/quera/quera_ahs_paradigm_properties_v1.py
+++ b/src/braket/device_schema/quera/quera_ahs_paradigm_properties_v1.py
@@ -90,6 +90,8 @@ class RydbergGlobal(BaseModel):
             parameters can be specified (measured in s)
         timeDeltaMin(Decimal): Minimum time step with which times for global Rydberg
             drive parameters can be specified (measured in s)
+        timeMin (Decimal): Minimum duration of Rydberg drive (measured in s)
+        timeMax (Decimal): Maximum duration of Rydberg drive (measured in s)
     """
 
     rabiFrequencyRange: Tuple[Decimal, Decimal]
@@ -103,6 +105,8 @@ class RydbergGlobal(BaseModel):
     phaseSlewRateMax: Decimal
     timeResolution: Decimal
     timeDeltaMin: Decimal
+    timeMin: Decimal
+    timeMax: Decimal
 
 
 class RydbergLocal(BaseModel):
@@ -144,13 +148,11 @@ class Rydberg(BaseModel):
     Attributes:
         c6Coefficient (Decimal): Rydberg-Rydberg C6 interaction
             coefficient (measured in (rad/s)*m^6)
-        timeMax (Decimal): Maximum duration of Rydberg drive (measured in s)
         rydbergGlobal: Rydberg Global
         rydbergLocal: Rydberg Local
     """
 
     c6Coefficient: Decimal
-    timeMax: Decimal
     rydbergGlobal: RydbergGlobal
     rydbergLocal: RydbergLocal
 
@@ -318,7 +320,6 @@ class QueraAhsParadigmProperties(BraketSchemaBase):
         ...     },
         ...     "rydberg": {
         ...         "c6Coefficient": 2*math.pi(3.14) *862690,
-        ...         "timeMax": 4.0e-6,
         ...         "rydbergGlobal": {
         ...             "rabiFrequencyRange": [0, 2*math.pi(3.14) *4.0e6],
         ...             "rabiFrequencyResolution": 400
@@ -331,6 +332,8 @@ class QueraAhsParadigmProperties(BraketSchemaBase):
         ...             "phaseSlewRateMax": 2*math.pi(3.14) /100e-9,
         ...             "timeResolution": 1e-9,
         ...             "timeDeltaMin": 1e-8,
+        ...             "timeMin": 0,
+        ...             "timeMax": 4.0e-6,
         ...         },
         ...         "rydbergLocal": {
         ...             "detuningRange": [0,2*math.pi(3.14) *50.0e6],

--- a/test/unit_tests/braket/device_schema/quera/test_quera_ahs_paradigm_properties_v1.py
+++ b/test/unit_tests/braket/device_schema/quera/test_quera_ahs_paradigm_properties_v1.py
@@ -48,7 +48,6 @@ def valid_input():
         },
         "rydberg": {
             "c6Coefficient": 2 * math.pi * 862690,
-            "timeMax": 4.0e-6,
             "rydbergGlobal": {
                 "rabiFrequencyRange": [0, 2 * math.pi * 4.0e6],
                 "rabiFrequencyResolution": 400,
@@ -61,6 +60,8 @@ def valid_input():
                 "phaseSlewRateMax": 2 * math.pi / 100e-9,
                 "timeResolution": 1e-9,
                 "timeDeltaMin": 1e-8,
+                "timeMin": 0,
+                "timeMax": 4.0e-6,
             },
             "rydbergLocal": {
                 "detuningRange": [0, 2 * math.pi * 50.0e6],

--- a/test/unit_tests/braket/device_schema/quera/test_quera_device_capabilities_v1.py
+++ b/test/unit_tests/braket/device_schema/quera/test_quera_device_capabilities_v1.py
@@ -76,7 +76,6 @@ def valid_input():
             },
             "rydberg": {
                 "c6Coefficient": 2 * math.pi * 862690,
-                "timeMax": 4.0e-6,
                 "rydbergGlobal": {
                     "rabiFrequencyRange": [0, 2 * math.pi * 4.0e6],
                     "rabiFrequencyResolution": 400,
@@ -89,6 +88,8 @@ def valid_input():
                     "phaseSlewRateMax": 2 * math.pi / 100e-9,
                     "timeResolution": 1e-9,
                     "timeDeltaMin": 1e-8,
+                    "timeMin": 0,
+                    "timeMax": 4.0e-6,
                 },
                 "rydbergLocal": {
                     "detuningRange": [0, 2 * math.pi * 50.0e6],


### PR DESCRIPTION
*Description of changes:*

* `timeMax` attribute is migrated from `QueraAhsParadigmProperties.rydberg.timeMax` to `QueraAhsParadigmProperties.rydberg.rydbergGlobal.timeMax`.
* `timeMin` attribute is added to `QueraAhsParadigmProperties.rydberg.rydbergGlobal.timeMin`.

*Testing done:*

Changed unit tests accordingly. Tested with current QuEra device.

## Merge Checklist

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-schemas-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-schemas-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-schemas-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-schemas-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
