### PR TITLE
decimals serialized as strings

### DIFF
--- a/src/braket/ir/ahs/program_v1.py
+++ b/src/braket/ir/ahs/program_v1.py
@@ -13,6 +13,7 @@
 
 
 from pydantic import BaseModel, Field
+from decimal import Decimal
 
 from braket.ir.ahs.atom_array import AtomArray
 from braket.ir.ahs.hamiltonian import Hamiltonian
@@ -49,3 +50,6 @@ class Program(BraketSchemaBase):
     braketSchemaHeader: BraketSchemaHeader = Field(default=_PROGRAM_HEADER, const=_PROGRAM_HEADER)
     setup: Setup
     hamiltonian: Hamiltonian
+
+    class Config:
+        json_encoders = {Decimal: str}

--- a/test/unit_tests/braket/ir/ahs/test_ahs_program_v1.py
+++ b/test/unit_tests/braket/ir/ahs/test_ahs_program_v1.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 
 import pytest
+from decimal import Decimal
 from pydantic import ValidationError
 
 from braket.ir.ahs.program_v1 import Program
@@ -85,3 +86,19 @@ def test__missing_hamiltonian():
     Program(
         setup=valid_setup_input,
     )
+
+
+def test_correct_decimal_serialization():
+    program = Program(
+        setup=valid_setup_input,
+        hamiltonian=valid_hamiltonian_input,
+    )
+    program.hamiltonian.drivingFields[0].amplitude.sequence.times = [Decimal(i * 3e-6 / 7) for i in range(8)]
+    program.hamiltonian.drivingFields[0].amplitude.sequence.values = [Decimal(0.0)] * 8
+
+    serialized_program = program.json()
+    deserialized_program = Program.parse_raw(serialized_program)
+
+    original_ampltiude_times = program.hamiltonian.drivingFields[0].amplitude.sequence.times
+    new_amplitude_times = deserialized_program.hamiltonian.drivingFields[0].amplitude.sequence.times
+    assert new_amplitude_times == original_ampltiude_times

--- a/test/unit_tests/braket/ir/ahs/test_ahs_program_v1.py
+++ b/test/unit_tests/braket/ir/ahs/test_ahs_program_v1.py
@@ -99,6 +99,6 @@ def test_correct_decimal_serialization():
     serialized_program = program.json()
     deserialized_program = Program.parse_raw(serialized_program)
 
-    original_ampltiude_times = program.hamiltonian.drivingFields[0].amplitude.sequence.times
+    original_amplitude_times = program.hamiltonian.drivingFields[0].amplitude.sequence.times
     new_amplitude_times = deserialized_program.hamiltonian.drivingFields[0].amplitude.sequence.times
-    assert new_amplitude_times == original_ampltiude_times
+    assert new_amplitude_times == original_amplitude_times


### PR DESCRIPTION
*Description of changes:*

A customer json encoder is added to `braket.ir.ahs.program_v1.Program` to ensure that `Decimal`s are serializes as strings. This preserves their number of significant digits, even if the float representation is inaccurate.

*Testing done:*

Not yet, I need help to understand how to test this.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-schemas-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-schemas-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-schemas-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-schemas-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
