### PR TITLE
feature: add getTaskPollIntervalMillis to device service properties

### DIFF
--- a/src/braket/device_schema/device_service_properties_v1.py
+++ b/src/braket/device_schema/device_service_properties_v1.py
@@ -80,6 +80,8 @@ class DeviceServiceProperties(BraketSchemaBase):
             details like image, summary etc.
         deviceLocation (Optional[str]): location fo the device
         updatedAt (Optional[datetime]): time when the device properties are last updated.
+        getTaskPollIntervalMillis (Optional[int]): (suggested) interval between polling tasks
+            in milliseconds.
 
     Examples:
         >>> import json
@@ -106,7 +108,8 @@ class DeviceServiceProperties(BraketSchemaBase):
         ...        "externalDocumentationUrl": "exter doc link",
         ...    },
         ...    "deviceLocation": "us-east-1",
-        ...    "updatedAt": "2020-06-16T19:28:02.869136"
+        ...    "updatedAt": "2020-06-16T19:28:02.869136",
+        ...    "getTaskPollIntervalMillis": 200,
         ... }
         >>> DeviceServiceProperties.parse_raw_schema(json.dumps(input_json))
 
@@ -122,3 +125,4 @@ class DeviceServiceProperties(BraketSchemaBase):
     deviceDocumentation: Optional[DeviceDocumentation]
     deviceLocation: Optional[str]
     updatedAt: Optional[datetime]
+    getTaskPollIntervalMillis: Optional[int]

--- a/test/unit_tests/braket/device_schema/test_device_service_properties_v1.py
+++ b/test/unit_tests/braket/device_schema/test_device_service_properties_v1.py
@@ -19,7 +19,7 @@ from pydantic import ValidationError
 from braket.device_schema.device_service_properties_v1 import DeviceServiceProperties
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def valid_input():
     input = {
         "braketSchemaHeader": {
@@ -40,6 +40,12 @@ def valid_input():
         "updatedAt": "2020-06-16T19:28:02.869136",
     }
     return input
+
+
+@pytest.fixture()
+def valid_input_with_getTaskPollInterval(valid_input):
+    valid_input["getTaskPollIntervalMillis"] = 200
+    return valid_input
 
 
 def test_valid(valid_input):
@@ -63,3 +69,16 @@ def test__missing_executionWindows(valid_input):
 def test__missing_shots(valid_input):
     valid_input.pop("shotsRange")
     DeviceServiceProperties.parse_raw_schema(json.dumps(valid_input))
+
+
+def test_parse_valid_input_without_getTaskPollIntervalMillis(valid_input):
+    assert "getTaskPollIntervalMillis" not in valid_input
+    service_props = DeviceServiceProperties.parse_raw_schema(json.dumps(valid_input))
+    assert not service_props.getTaskPollIntervalMillis
+
+
+def test_parse_valid_input_with_getTaskPollInterval(valid_input_with_getTaskPollInterval):
+    service_props = DeviceServiceProperties.parse_raw_schema(
+        json.dumps(valid_input_with_getTaskPollInterval)
+    )
+    assert service_props.getTaskPollIntervalMillis == 200


### PR DESCRIPTION
*Description of changes:* This pr adds to device service properties a new optional informational field providing suggested interval for GetQuantumTask polls when the task is not finished.

*Testing done:* tox

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-schemas-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-schemas-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-schemas-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-schemas-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
